### PR TITLE
React 13 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-falcor",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A helper library for integratig Redux & Falcor",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/components/FalcorProvider.js
+++ b/src/components/FalcorProvider.js
@@ -63,7 +63,8 @@ export default class FalcorProvider extends Component {
   }
 
   render() {
-    const { children } = this.props;
-    return Children.only(children);
+    let {children} = this.props
+    children = children()
+    return children
   }
 }

--- a/src/components/FalcorProvider.js
+++ b/src/components/FalcorProvider.js
@@ -1,5 +1,6 @@
 import { Component, PropTypes, Children } from 'react';
 import expandCache from 'falcor-expand-cache';
+import invariant from 'invariant';
 
 import createStore from './createStore';
 
@@ -53,6 +54,11 @@ export default class FalcorProvider extends Component {
     this.falcor = props.falcor;
     this.falcorStore = createStore(props.store);
     attachOnChange(props.falcor, this.falcorStore);
+
+    invariant(false,
+      `This is a React 0.13 patch, after upgrade to React 14 is complete remove @laurelandwolf/redux-falcor` +
+      `from package.json and replace with "redux-falcor"`
+    )
   }
 
   getChildContext() {


### PR DESCRIPTION
Instead of expecting a React element the component will accept an anonymous function that return a React element. This is a workaround for context issues in React 0.13 and is not needed in React 14

Ref: https://medium.com/@skwee357/the-land-of-undocumented-react-js-the-context-99b3f931ff73#.yzdq1sitm
